### PR TITLE
Small cleanup

### DIFF
--- a/lib/matrix.ex
+++ b/lib/matrix.ex
@@ -25,7 +25,7 @@ defmodule Matrix do
       [[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, 1]]
   """
   @vsn 1
-  @doc """
+  @typedoc """
       A list of values representing a matrix row.
   """
   @type row :: [number]
@@ -84,11 +84,11 @@ defmodule Matrix do
     numbers between 0 and 1.
 
     #### Examples
-        iex> _ = :random.seed(12345)
+        iex> _ = :rand.seed(:exs1024, {123, 123534, 345345})
         iex> Matrix.rand(3,3)
-        [[0.07797290969719865, 0.3944785128151924, 0.9781224924937147],
-         [1.3985610037403617e-4, 0.5536761216397539, 0.35476183770551284],
-         [0.7021763747372531, 0.5537966721193639, 0.1607491687700906]]
+        [[0.5820506340260994, 0.6739535732076178, 0.9178030245386003],
+         [0.7402049520743949, 0.5589108995145826, 0.8687305849540213],
+         [0.8851580858928109, 0.988438251464987, 0.18105169154176423]]
 
     #### See also
     [new/3](#new/3), [ones/2](#ones/2), [zeros/2](#zeros/2)
@@ -99,7 +99,7 @@ defmodule Matrix do
   end
 
   def make_random_row(0), do: []
-  def make_random_row(n), do: [:random.uniform] ++ make_random_row(n-1)
+  def make_random_row(n), do: [:rand.uniform] ++ make_random_row(n-1)
 
 
 

--- a/mix.exs
+++ b/mix.exs
@@ -15,12 +15,11 @@ defmodule Matrix.Mixfile do
   #
   # Type "mix help compile.app" for more information
   def application do
-    [applications: [:logger]]
+    [applications: [:logger, :exprintf]]
   end
 
   defp deps do
-    [{:earmark, "~> 0.1"},
-     {:ex_doc, github: "elixir-lang/ex_doc"},
+    [{:ex_doc, "~> 0.14", only: :dev},
      {:exprintf, "~> 0.1"}]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,3 +1,3 @@
-%{"earmark": {:hex, :earmark, "0.1.19"},
-  "ex_doc": {:git, "https://github.com/elixir-lang/ex_doc.git", "c7c16f2372566350303b9c81c49ab585472407ac", []},
-  "exprintf": {:hex, :exprintf, "0.1.6"}}
+%{"earmark": {:hex, :earmark, "1.0.1", "2c2cd903bfdc3de3f189bd9a8d4569a075b88a8981ded9a0d95672f6e2b63141", [:mix], []},
+  "ex_doc": {:hex, :ex_doc, "0.14.1", "bfed8d4e93c755e2b150be925ad2cfa6af7c3bfcacc3b609f45f6048c9d623d6", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]},
+  "exprintf": {:hex, :exprintf, "0.1.6", "b5b0a38bf78a357dbc61cdf7364fea004af6fdf5214be44021eb2ea7edf61f6e", [:mix], []}}


### PR DESCRIPTION
* Point ex_doc at the hex release, make it `only: :dev` so that it does not show up in production releases
* Remove earmark from the deps list (this is no longer required afaik)
* Add `:exprintf` to the application list so that it gets picked up for production releases
* `@typedoc` compiler warning
* Convert from `:random` to `:rand`, update test case.