### PR TITLE
Add pivoting to row reduction

### DIFF
--- a/lib/matrix.ex
+++ b/lib/matrix.ex
@@ -407,6 +407,10 @@ defmodule Matrix do
       iex> res = Matrix.mult( x, Matrix.inv(x) )
       iex> Matrix.almost_equal(res,[[1,0,0],[0,1,0],[0,0,1]])
       true
+      iex> y = [[-2, -1, -6, -1], [6, 3, 6, -1], [-3, -2, 12, 8], [0, -1, -6, -8]]
+      iex> res = Matrix.mult( y, Matrix.inv(y) )
+      iex> Matrix.almost_equal(res, Matrix.ident(4))
+      true
   """
   @spec inv(matrix) :: matrix
   def inv(x) do

--- a/lib/matrix.ex
+++ b/lib/matrix.ex
@@ -400,7 +400,8 @@ defmodule Matrix do
   matrix.  If the supplied matrix is "x" then, by definition,
           x * inv(x) = I
   where I is the identity matrix.  This function uses a brute force Gaussian
-  elimination so it is not expected to be terribly fast.
+  elimination so it is not expected to be terribly fast.  It is also expected
+  to generate an ArithmeticError when passed a singular matrix.
 
   #### Examples
       iex> x = Matrix.rand(5,5)
@@ -411,6 +412,8 @@ defmodule Matrix do
       iex> res = Matrix.mult( y, Matrix.inv(y) )
       iex> Matrix.almost_equal(res, Matrix.ident(4))
       true
+      iex> Matrix.inv([[1, 2, 3], [4, 5, 6], [3, 6, 9]])
+      ** (ArithmeticError) bad argument in arithmetic expression
   """
   @spec inv(matrix) :: matrix
   def inv(x) do


### PR DESCRIPTION
This is a proposed fix for the issue (https://github.com/twist-vector/elixir-matrix/issues/10) I filed, where the matrix inverse will silently return
incorrect results if it happens to run across small values while performing row reduction.  This fix will work as long for any non-singular matrix: singular matrices may generate an ArithmeticError (division by zero), or just crazy values from inverting  floating point numbers very close to zero.  This is still far better than the current defective behavior.